### PR TITLE
feat: add custom JWT serializer and include user type in token claims

### DIFF
--- a/backend/users/jwt_serializers.py
+++ b/backend/users/jwt_serializers.py
@@ -10,7 +10,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     This serializer extends the default TokenObtainPairSerializer to include
     custom claims in the JWT token:
         - type: The user's type (e.g., role or user category).
-        - is_active: Boolean indicating if the user account is active.
+        - status: The user's status (e.g., active, inactive, suspended).
     """
 
     @classmethod

--- a/backend/users/jwt_serializers.py
+++ b/backend/users/jwt_serializers.py
@@ -1,0 +1,10 @@
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+        # Add custom claims
+        token['type'] = user.type
+        token['is_active'] = user.is_active
+        return token

--- a/backend/users/jwt_serializers.py
+++ b/backend/users/jwt_serializers.py
@@ -2,6 +2,14 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """
+    Custom serializer for obtaining JWT tokens with additional user claims.
+
+    This serializer extends the default TokenObtainPairSerializer to include
+    custom claims in the JWT token:
+        - type: The user's type (e.g., role or user category).
+        - is_active: Boolean indicating if the user account is active.
+    """
     @classmethod
     def get_token(cls, user):
         token = super().get_token(user)

--- a/backend/users/jwt_serializers.py
+++ b/backend/users/jwt_serializers.py
@@ -1,10 +1,11 @@
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
+
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     @classmethod
     def get_token(cls, user):
         token = super().get_token(user)
         # Add custom claims
-        token['type'] = user.type
-        token['is_active'] = user.is_active
+        token["type"] = user.type
+        token["is_active"] = user.is_active
         return token

--- a/backend/users/jwt_serializers.py
+++ b/backend/users/jwt_serializers.py
@@ -1,5 +1,7 @@
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
+from .models import User
+
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     """
@@ -10,10 +12,11 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         - type: The user's type (e.g., role or user category).
         - is_active: Boolean indicating if the user account is active.
     """
+
     @classmethod
     def get_token(cls, user):
         token = super().get_token(user)
         # Add custom claims
-        token["type"] = user.type
-        token["is_active"] = user.is_active
+        token["type"] = getattr(user, "type", None)
+        token["status"] = getattr(user, "status", User.INACTIVE)
         return token

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -123,11 +123,12 @@ class UserPasswordUpdateSerializer(serializers.Serializer):
 
 
 class UserTokenValidationSerializer(serializers.Serializer):
-    user_id = serializers.IntegerField(read_only=True)
+    user_id = serializers.UUIDField(read_only=True)
     email = serializers.EmailField(read_only=True)
     full_name = serializers.CharField(read_only=True)
     status = serializers.CharField(read_only=True)
     is_active = serializers.BooleanField(read_only=True)
+    type = serializers.CharField(read_only=True)
 
 
 class UserInitialPasswordSerializer(serializers.Serializer):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -4,6 +4,7 @@ from rest_framework import generics, permissions, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
+
 from users.jwt_serializers import CustomTokenObtainPairSerializer
 
 from .models import User
@@ -24,6 +25,7 @@ class UserListCreateView(generics.ListCreateAPIView):
     List all users or create a new user
     Requires authentication - only teammates can access
     """
+
     queryset = User.objects.filter(status=User.ACTIVE)
     permission_classes = [permissions.IsAuthenticated]
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -4,6 +4,7 @@ from rest_framework import generics, permissions, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
+from users.jwt_serializers import CustomTokenObtainPairSerializer
 
 from .models import User
 from .serializers import (
@@ -23,7 +24,6 @@ class UserListCreateView(generics.ListCreateAPIView):
     List all users or create a new user
     Requires authentication - only teammates can access
     """
-
     queryset = User.objects.filter(status=User.ACTIVE)
     permission_classes = [permissions.IsAuthenticated]
 
@@ -64,8 +64,6 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
 
 
 # User Authentication Views
-
-
 class UserRegistrationView(generics.CreateAPIView):
     """
     User registration endpoint - allows users to self-register
@@ -97,8 +95,8 @@ class UserLoginView(generics.GenericAPIView):
         user.last_login = timezone.now()
         user.save()
 
-        # Generate JWT tokens
-        refresh = RefreshToken.for_user(user)
+        # Generate JWT tokens with custom claims
+        refresh = CustomTokenObtainPairSerializer.get_token(user)
 
         return Response(
             {
@@ -224,6 +222,7 @@ def validate_user_token(request):
                 "full_name": user.get_full_name(),
                 "status": user.status,
                 "is_active": user.is_active,
+                "type": user.type,
             }
         )
         return Response(


### PR DESCRIPTION
This pull request introduces enhancements to user authentication and serialization in the backend. The main changes add custom claims to JWT tokens, update user-related serializers to include additional fields, and ensure these changes are reflected in authentication and user validation endpoints.

**Authentication and JWT Token Enhancements:**

* Added a new `CustomTokenObtainPairSerializer` that extends the default JWT serializer to include custom claims (`type` and `is_active`) in the token payload.
* Updated the login endpoint to use the new `CustomTokenObtainPairSerializer` for generating JWT tokens with the custom claims. [[1]](diffhunk://#diff-b1fe141c72c34bee31a1d2ff2a2a74b7f1d2ca6a33a86ac42f9dfdb42dc0a24aL100-R99) [[2]](diffhunk://#diff-b1fe141c72c34bee31a1d2ff2a2a74b7f1d2ca6a33a86ac42f9dfdb42dc0a24aR7)

**User Serialization Improvements:**

* Modified `UserTokenValidationSerializer` to use a UUID for `user_id` and added a `type` field to the serialized output.
* Updated the user token validation endpoint to include the user's `type` in the response.

**Minor Code Cleanups:**

* Removed unnecessary blank lines and improved code formatting in `users/views.py`. [[1]](diffhunk://#diff-b1fe141c72c34bee31a1d2ff2a2a74b7f1d2ca6a33a86ac42f9dfdb42dc0a24aL26) [[2]](diffhunk://#diff-b1fe141c72c34bee31a1d2ff2a2a74b7f1d2ca6a33a86ac42f9dfdb42dc0a24aL67-L68)