### PR TITLE
chore: move registration endpoint to internal api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ DB_HOST=db
 DB_PORT=5432
 ALLOWED_HOSTS=0.0.0.0,localhost,render.com
 INTERNAL_JWT_SECRET_KEY=your-internal-jwt-secret-key
+INTERNAL_JWT_ALLOWED_SERVICES=sugarfoot,koda,gary

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -173,7 +173,7 @@ SIMPLE_JWT = {
 }
 
 
-INTERNAL_JWT_SECRET_KEY = config("INTERNAL_JWT_SECRET_KEY", default="internal-default")
+INTERNAL_JWT_SECRET_KEY = config("INTERNAL_JWT_SECRET_KEY", default="your-internal-jwt-secret-key")
 INTERNAL_JWT_ALLOWED_SERVICES = config(
-    "INTERNAL_JWT_ALLOWED_SERVICES", default="sugarfoot"
+    "INTERNAL_JWT_ALLOWED_SERVICES", default="sugarfoot,gary"
 ).split(",")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -173,7 +173,9 @@ SIMPLE_JWT = {
 }
 
 
-INTERNAL_JWT_SECRET_KEY = config("INTERNAL_JWT_SECRET_KEY", default="your-internal-jwt-secret-key")
+INTERNAL_JWT_SECRET_KEY = config(
+    "INTERNAL_JWT_SECRET_KEY", default="your-internal-jwt-secret-key"
+)
 INTERNAL_JWT_ALLOWED_SERVICES = config(
     "INTERNAL_JWT_ALLOWED_SERVICES", default="sugarfoot,gary"
 ).split(",")

--- a/backend/users/middleware.py
+++ b/backend/users/middleware.py
@@ -12,17 +12,17 @@ class InternalJWTAuthMiddleware:
         if request.path.startswith("/api/users/internal/"):
             auth_header = request.headers.get("Authorization", "")
             if not auth_header.startswith("Bearer "):
-                return JsonResponse({"error": "Unauthorized"}, status=401)
+                return JsonResponse({"error": "Unauthorized request"}, status=401)
             token = auth_header.split(" ")[1]
             try:
                 payload = jwt.decode(
                     token, settings.INTERNAL_JWT_SECRET_KEY, algorithms=["HS256"]
                 )
                 allowed_services = getattr(
-                    settings, "INTERNAL_JWT_ALLOWED_SERVICES", ["sugarfoot"]
+                    settings, "INTERNAL_JWT_ALLOWED_SERVICES", ["sugarfoot", "gary"]
                 )
                 if payload.get("service") not in allowed_services:
-                    return JsonResponse({"error": "Unauthorized"}, status=401)
+                    return JsonResponse({"error": "Service unauthorized"}, status=401)
             except jwt.ExpiredSignatureError:
                 return JsonResponse({"error": "Token expired"}, status=401)
             except jwt.InvalidTokenError:

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -190,7 +190,7 @@ class UserAuthenticationTestCase(APITestCase):
 
     def setUp(self):
         """Set up test data before each test"""
-        self.register_url = "/api/users/register/"
+        self.register_url = "/api/users/internal/register/"
         self.login_url = "/api/users/login/"
         self.profile_url = "/api/users/me/"
         self.password_url = "/api/users/me/password/"

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -6,7 +6,7 @@ internal_patterns = [
     path(
         "by-email/<str:email>/", views_internal.get_user_by_email, name="user-by-email"
     ),
-    path("register/", views.UserRegistrationView.as_view(), name="user-register"),
+    path("register/", views_internal.UserRegistrationView.as_view(), name="user-register"),
     # Add more internal endpoints here
 ]
 

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -6,6 +6,7 @@ internal_patterns = [
     path(
         "by-email/<str:email>/", views_internal.get_user_by_email, name="user-by-email"
     ),
+    path("register/", views.UserRegistrationView.as_view(), name="user-register"),
     # Add more internal endpoints here
 ]
 
@@ -14,7 +15,6 @@ urlpatterns = [
     path("", views.UserListCreateView.as_view(), name="user-list-create"),
     path("<uuid:pk>/", views.UserDetailView.as_view(), name="user-detail"),
     # User self-service authentication endpoints
-    path("register/", views.UserRegistrationView.as_view(), name="user-register"),
     path("login/", views.UserLoginView.as_view(), name="user-login"),
     path(
         "set-password/",

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -6,7 +6,9 @@ internal_patterns = [
     path(
         "by-email/<str:email>/", views_internal.get_user_by_email, name="user-by-email"
     ),
-    path("register/", views_internal.UserRegistrationView.as_view(), name="user-register"),
+    path(
+        "register/", views_internal.UserRegistrationView.as_view(), name="user-register"
+    ),
     # Add more internal endpoints here
 ]
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -13,7 +13,6 @@ from .serializers import (
     UserCreateSerializer,
     UserInitialPasswordSerializer,
     UserPasswordUpdateSerializer,
-    UserRegistrationSerializer,
     UserSerializer,
     UserTokenValidationSerializer,
     UserUpdateSerializer,
@@ -63,8 +62,6 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
         return Response(
             {"message": "User deactivated successfully"}, status=status.HTTP_200_OK
         )
-
-
 
 
 class UserLoginView(generics.GenericAPIView):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -65,19 +65,6 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
         )
 
 
-# User Authentication Views
-class UserRegistrationView(generics.CreateAPIView):
-    """
-    User registration endpoint - allows users to self-register
-    POST /api/users/register/ - Register new user with password
-    """
-
-    queryset = User.objects.all()
-    serializer_class = UserRegistrationSerializer
-    permission_classes = [permissions.AllowAny]
-
-    def perform_create(self, serializer):
-        serializer.save(date_joined=timezone.now())
 
 
 class UserLoginView(generics.GenericAPIView):

--- a/backend/users/views_internal.py
+++ b/backend/users/views_internal.py
@@ -1,22 +1,20 @@
 from urllib.parse import unquote
-from django.utils import timezone
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from rest_framework import generics, permissions, status
+from django.utils import timezone
 
-from rest_framework import status
+from rest_framework import generics, permissions, status
 from rest_framework.decorators import (
     api_view,
     authentication_classes,
     permission_classes,
 )
-
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from .models import User
-from .serializers import (UserSerializer, UserRegistrationSerializer)
+from .serializers import UserRegistrationSerializer, UserSerializer
 
 
 @api_view(["GET"])


### PR DESCRIPTION
This pull request updates the user registration endpoint routing in the `backend/users/urls.py` file. The main change is moving the `register/` endpoint from the public user self-service section to the internal endpoints section, which affects how user registration requests are routed and possibly who can access them.

**Routing changes:**

* Moved the `register/` endpoint from the public user self-service authentication endpoints to the internal endpoints section in `backend/users/urls.py`, changing its accessibility and grouping. [[1]](diffhunk://#diff-b28357d7a476143c4ad5e806eff82c68d1df9367f33d5f8908c79df694e8b637R9) [[2]](diffhunk://#diff-b28357d7a476143c4ad5e806eff82c68d1df9367f33d5f8908c79df694e8b637L17)